### PR TITLE
Developer

### DIFF
--- a/AnkiAudioTools.py
+++ b/AnkiAudioTools.py
@@ -2,6 +2,7 @@ import urllib.request
 import urllib.parse
 from enum import Enum
 from bs4 import BeautifulSoup 
+from aqt import mw
 import random
 
 languages = ['Abaza_abq', 'Abkhazian_ab', 'Adygean_ady', 'Afar_aa', 'Afrikaans_af', 'Aghul_agx', 'Akan_ak', 'Albanian_sq', 'Algerian Arabic_arq', 'Algonquin_alq',
@@ -49,8 +50,9 @@ class AnkiAudioObject:
     def getFilename(self): # used to be useful to access the vote amount
         return self.word + "-" + str(self.id) + "-" + self.votes + "." + self.link.split(".")[-1]
     def getBucketFilename(self): 
-        #filename without the votes.
-        return self.word + "-" + str(self.id) + "." + self.link.split(".")[-1]
+        #filename without the votes now used everywhere so a rename is needed. file extension now depends on config.
+        fileExtension = (mw.addonManager.getConfig(__name__)["audioFileExtension"] or self.link.split(".")[-1])
+        return self.word + "-" + str(self.id) + "." + fileExtension
     def getVotes(self):
         return int(self.votes.replace("votes", ""))
 

--- a/AnkiForvoAudioGenerator.py
+++ b/AnkiForvoAudioGenerator.py
@@ -2,9 +2,9 @@ from aqt.qt import *
 import sys
 import time
 from aqt import mw
-from AnkiSimpleForvoAudio.AnkiAudioTools import *
-from AnkiSimpleForvoAudio.bs4Scraper import scrapeAnkiAudioObject
-from AnkiSimpleForvoAudio.ovrofCDN import *
+from .AnkiAudioTools import *
+from .bs4Scraper import scrapeAnkiAudioObject
+from .ovrofCDN import *
 import random
 import unicodedata
 

--- a/AutoForvoTts.py
+++ b/AutoForvoTts.py
@@ -4,8 +4,8 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from aqt import mw
 from aqt.utils import showInfo
-from AnkiSimpleForvoAudio.AnkiForvoAudioGenerator import AnkiForvoAudioGenerator
-from AnkiSimpleForvoAudio.AnkiAudioTools import AnkiAudioTarget, AudioClearingOptions, AcquisitionType, AnkiAudioGlobals
+from .AnkiForvoAudioGenerator import AnkiForvoAudioGenerator
+from .AnkiAudioTools import AnkiAudioTarget, AudioClearingOptions, AcquisitionType, AnkiAudioGlobals
 
 # TODO: To anyone even remotely familiar with QT, this probably looks horrendous. Revamp encouraged. 
 

--- a/ForvoTts.py
+++ b/ForvoTts.py
@@ -9,29 +9,24 @@ from .AnkiAudioTools import languages, download_Audio, AnkiAudioGlobals, AnkiAud
 from .bs4Scraper import lookup_word
 import os
 import glob
+from threading import *
 
 # TODO: To anyone even remotely familiar with QT, this probably looks horrendous. Revamp encouraged. 
 
 class ForvoTts(QDialog):
     finalResult = None # to be a
-    def __init__(self, mw, targetNote, parent, focusedField):
+    def __init__(self, mw, targetNote, parent, focusedField, selectedText):
         QDialog.__init__(self, parent or mw)
         #super(ForvoTts, self).__init__(parent)
-        selectionText = QApplication.clipboard().text(1)
         self.textBox = QLineEdit(self)
         self.textBox.setGeometry(QRect(200, 50, 150, 30))
         self.textBox.setMinimumWidth(170)
         self.textBox.setPlaceholderText("Search...")
         self.config = mw.addonManager.getConfig(__name__)
         self.focusedField = focusedField
-        for fieldName in targetNote.keys():
-            if(selectionText in targetNote[fieldName]):
-                self.textBox.setText(selectionText)
-                break
-
+        self.textBox.setText(selectedText)
         self.targetNote = targetNote        
         self.setupUi(self)
-        
 
     def setupUi(self, Dialog):
         Dialog.setObjectName("TTSDialog")

--- a/ForvoTts.py
+++ b/ForvoTts.py
@@ -5,8 +5,8 @@ from PyQt5.Qt import *  # type: ignore
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from aqt import mw
-from AnkiSimpleForvoAudio.AnkiAudioTools import languages, download_Audio, AnkiAudioGlobals, AnkiAudioObject
-from AnkiSimpleForvoAudio.bs4Scraper import lookup_word
+from .AnkiAudioTools import languages, download_Audio, AnkiAudioGlobals, AnkiAudioObject
+from .bs4Scraper import lookup_word
 import os
 import glob
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,7 @@ from .AutoForvoTts import AutoForvoTts
 from .ForvoTts import ForvoTts
 from aqt import gui_hooks
 
+
 def openForvoAudioGenerator():
     cardCount = mw.col.cardCount()
     config = mw.addonManager.getConfig(__name__)
@@ -12,16 +13,17 @@ def openForvoAudioGenerator():
 
 action = QAction("Add Forvo TTS to deck", mw)
 action.triggered.connect(openForvoAudioGenerator)
-mw.form.menuTools.addAction(action)
+#mw.form.menuTools.addAction(action)
 
 def addForvoTtsOption(editerWindow, qmenu):
     qmenu.addAction("Add Forvo Audio", lambda: forvoTts(editerWindow))
+
 
 def forvoTts(editorWindow):
     editor = editorWindow.editor
     results = []
     note = editor.note
-    widget = ForvoTts(mw, note, editor.parentWindow, editor.currentField)
+    widget = ForvoTts(mw, note, editor.parentWindow, editor.currentField, editorWindow.selectedText())
     if(widget.exec_()):
         result = widget.finalResult
         editor.web.setFocus()

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 from aqt import mw
 from aqt.qt import *
-from AnkiSimpleForvoAudio.AutoForvoTts import AutoForvoTts
-from AnkiSimpleForvoAudio.ForvoTts import ForvoTts
+from .AutoForvoTts import AutoForvoTts
+from .ForvoTts import ForvoTts
 from aqt import gui_hooks
 
 def openForvoAudioGenerator():

--- a/bs4Scraper.py
+++ b/bs4Scraper.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 import base64
 import urllib.request
 import urllib.parse
-from AnkiSimpleForvoAudio.AnkiAudioTools import AnkiAudioObject, AnkiAudioGlobals
+from .AnkiAudioTools import AnkiAudioObject, AnkiAudioGlobals
 import string
 import unicodedata
 import sys

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "downloadPath":"",
     "ignorePunctuation": "True",
-    "MaxForvoDownloads": 100
+    "MaxForvoDownloads": 100,
+    "audioFileExtension": "mp3" 
 }

--- a/ovrofCDN.py
+++ b/ovrofCDN.py
@@ -1,8 +1,8 @@
 import urllib.request
 import urllib.parse
 import json
-from AnkiSimpleForvoAudio.AnkiAudioTools import AnkiAudioObject, AnkiAudioGlobals
-from AnkiSimpleForvoAudio.bs4Scraper import lookup_word
+from .AnkiAudioTools import AnkiAudioObject, AnkiAudioGlobals
+from .bs4Scraper import lookup_word
 from aqt import mw
 
 '''


### PR DESCRIPTION
1 **fix**, 1 **change**.

- **Fixed**: Automatically adding selected text to the Audio adding Dialog now works correctly on Windows and (possibly) MacOS.
- **Changed**: All audio files now get the `.mp3` file extension by default (you can change it back to `.ogg` in the config as `"audioFileExtension": "ogg"`). This was done to support AnkiWeb and (possibly) the anki IOS app that only support mp3 files (though all I did was change the extenstion, the addon still downloads the ogg file, worked on AnkiWeb).

  
